### PR TITLE
feat(frontend): fixed all known bugs on frontend, made small changes …

### DIFF
--- a/frontend/src/atoms.ts
+++ b/frontend/src/atoms.ts
@@ -1,7 +1,7 @@
 import { RecoilState, atom } from "recoil";
 import { LocationPopupInfo } from "./hooks/useLocationPopup";
 import { CircleLayer } from "mapbox-gl";
-import { circleLayerr } from "./heatmapLayer";
+import { circleLayerDefault } from "./heatmapLayer";
 import {
   Feature,
   FeatureCollection,
@@ -70,7 +70,7 @@ export const locationPopupInfoState: RecoilState<LocationPopupInfo | null> =
 
 export const circleLayerState: RecoilState<CircleLayer> = atom({
   key: "circleLayer",
-  default: circleLayerr,
+  default: circleLayerDefault,
 });
 
 export const mapViewStateState: RecoilState<any> = atom({

--- a/frontend/src/components/SearchResults.tsx
+++ b/frontend/src/components/SearchResults.tsx
@@ -51,7 +51,10 @@ const SearchResults = () => {
 
   const numPages = searchResults.length/10;
 
-  const interpolater = d3.interpolateRgbBasis(["red", "yellow", "green"]);
+  const colorScale = d3.scaleLinear(
+    [0, 0.2, 0.5, 0.8, 1],  // input values
+    ["red", "red", "yellow", "green", "green"] // output colors
+  ); 
 
   return (
     <Paper
@@ -72,8 +75,14 @@ const SearchResults = () => {
               <ListItemIcon>
                 <NewspaperIcon />
               </ListItemIcon>
-              <Stack alignItems={"center"} direction="row" spacing={2}>
+              <Stack 
+                alignItems={"center"} 
+                justifyContent={"space-between"} 
+                direction="row" 
+                width="100%"
+                spacing={2}>
                 <ListItemText
+                  style={{flexGrow: 1}}
                   primary={result.webTitle}
                   secondary={
                     <Typography 
@@ -87,18 +96,21 @@ const SearchResults = () => {
                     </Typography>
                   }
                 />
-                <CircleIcon
-                  style={{
-                    color: interpolater(result.sentimentScore),
-                    fontSize: "20px",
-                  }}
-                />
-                <img
-                  src={result.thumbnail}
-                  alt="Article image"
-                  width="100px"
-                  style={{ borderRadius: "5px" }}
-                />
+                <Stack direction="row" alignItems={"center"} spacing={2}>
+                  <CircleIcon
+                    style={{
+                      color: colorScale(result.sentimentScore),
+                      fontSize: "20px",
+                    }}
+                  />
+                  <img
+                    src={result.thumbnail}
+                    alt="Article image"
+                    width="100px"
+                    style={{ borderRadius: "5px" }}
+                  />
+                </Stack>
+                
               </Stack>
             </ListItemButton>
           </Link>

--- a/frontend/src/components/locationPopup/LocationPopup.tsx
+++ b/frontend/src/components/locationPopup/LocationPopup.tsx
@@ -21,8 +21,10 @@ const LocationPopup = ({
   const selectedYear = useRecoilValue(selectedYearState);
   const selectedMonth = useRecoilValue(selectedMonthState);
 
-  const sentimentKey = (selectedMonth ? `${selectedMonth.toString()}-${selectedYear.toString()}` : `${selectedYear.toString()}`) + '-sentiment';
+  const sentimentKey = (selectedMonth ? `${selectedMonth.toString().padStart(2, "0")}-${selectedYear.toString()}` : `${selectedYear.toString()}`) + '-sentiment';
   const scrollRef = useRef<mapboxgl.Popup>(null);
+
+  console.error(sentimentKey);
 
   useEffect(() => {
     if (scrollRef.current) {
@@ -58,6 +60,9 @@ const LocationPopup = ({
               <Typography component="p">{article.description}</Typography>
             </>
           ))} */}
+          {
+
+          }
           <Stack>
             <Typography
               variant="h3"
@@ -65,7 +70,7 @@ const LocationPopup = ({
               fontWeight="bold"
               color="primary"
             >
-              {info.properties && info.properties[sentimentKey].toFixed(2)}
+              {info.properties && info.properties[sentimentKey] && info.properties[sentimentKey].toFixed(2)}
             </Typography>
             <Typography component="p" color="primary">
               Avg. Sentiment

--- a/frontend/src/components/overviewPanel/OverviewPanel.css
+++ b/frontend/src/components/overviewPanel/OverviewPanel.css
@@ -12,12 +12,7 @@
   cursor: pointer;
 }
 
-/** VERY IMPORTANT, DON'T REMOVE*/
-.css-142xza3-MuiGrid-root>.MuiGrid-item{
-  padding: 0px !important;
-}
 
-.css-1nblqo2-MuiGrid-root>.MuiGrid-item{
-  padding-left: 0px !important;
-  padding-top: 0px !important;
+.unfold-more-container{
+    padding: 0px !important;  
 }

--- a/frontend/src/components/overviewPanel/OverviewPanel.tsx
+++ b/frontend/src/components/overviewPanel/OverviewPanel.tsx
@@ -45,7 +45,10 @@ export const OverviewPanel = ({
     }
   };
 
-  const interpolater = d3.interpolateRgbBasis(["red", "yellow", "green"]);
+  const colorScale = d3.scaleLinear(
+    [0, 0.2, 0.5, 0.8, 1],  // input values
+    ["red", "red", "yellow", "green", "green"] // output colors
+  ); 
 
   const renderTopFiveList = (
     list: LocationToDetailsMap[],
@@ -87,7 +90,7 @@ export const OverviewPanel = ({
               {isCountList && (
                 <CircleIcon
                   style={{
-                    color: interpolater(sentimentScore),
+                    color: colorScale(sentimentScore),
                     fontSize: "10px",
                   }}
                 />
@@ -123,12 +126,12 @@ export const OverviewPanel = ({
         maxWidth: "70vw",
         padding: isExpandedOverviewPanel ? "0px" : "5px",
         paddingBottom: isExpandedOverviewPanel ? "5px" : "0px",
-        paddingRight: isExpandedOverviewPanel ? "5px" : "0px"
+        paddingRight: "5px"
       }}
     >
       {isExpandedOverviewPanel ? (
         <>
-          <Grid item>
+          <Grid item width='100%'>
             <Stack
               className="header-container"
               direction="row"
@@ -184,7 +187,9 @@ export const OverviewPanel = ({
           </Grid>
         </>
       ) : (
-        <Grid item>
+        <Grid 
+          className='unfold-more-container'
+          item>
           <UnfoldMoreIcon
             className="toggle-icon"
             data-testid="overview-maximize-button"

--- a/frontend/src/heatmapLayer.ts
+++ b/frontend/src/heatmapLayer.ts
@@ -31,7 +31,13 @@ export const updateHeatMapLayer = (
     "-count";
 
   const maxCount = getMaxArticleCount(countKey, features);
-  if (maxCount > 10 && maxCount <= 15) return null;
+
+  const MIN_ZOOM_MIN_CIRCLE_SIZE = 1;
+  const MIN_ZOOM_MAX_CIRCLE_SIZE = 50;
+
+  const MED_ZOOM_MIN_CIRCLE_SIZE = 5;
+  const MED_ZOOM_MAX_CIRCLE_SIZE = 15;
+
   const circleLayer: CircleLayer = {
     id: "heatmap",
     type: "circle",
@@ -44,31 +50,23 @@ export const updateHeatMapLayer = (
         ["zoom"],
         0,
         [
-          "step",
+          "interpolate",
+          ["linear"],
           ["get", countKey],
-          3,
-          5,
-          10,
-          10,
-          20,
-          15,
-          30,
-          80,
-          20, // default value
+          0,
+          MIN_ZOOM_MIN_CIRCLE_SIZE,
+          maxCount,
+          MIN_ZOOM_MAX_CIRCLE_SIZE,
         ],
         8,
         [
-          "step",
+          "interpolate",
+          ["linear"],
           ["get", countKey],
-          5,
-          10,
-          10,
-          12,
-          20,
-          13,
-          30,
-          15,
-          20, // default value
+          0,
+          MED_ZOOM_MIN_CIRCLE_SIZE,
+          maxCount,
+          MED_ZOOM_MAX_CIRCLE_SIZE,
         ],
       ],
       // color of the circle based on sentiment
@@ -77,9 +75,11 @@ export const updateHeatMapLayer = (
         ["linear"],
         ["get", sentimentKey],
         0.2,
-        "#ff0000", // Low sentiment
-        0.7,
-        "#00ff00", // High sentiment
+        "#ff0000", // low sentiment (red)
+        0.5,
+        "#ffff00", // medium sentiment (yellow)
+        0.8,
+        "#00ff00", // high sentiment (green)
       ],
       "circle-opacity": 0.75,
     },
@@ -87,7 +87,7 @@ export const updateHeatMapLayer = (
   return circleLayer;
 };
 
-export const circleLayerr: CircleLayer = {
+export const circleLayerDefault: CircleLayer = {
   id: "heatmap",
   type: "circle",
   paint: {
@@ -135,65 +135,3 @@ export const circleLayerr: CircleLayer = {
     "circle-opacity": 0.75,
   },
 };
-
-// export const heatmapLayer: HeatmapLayer = {
-//   id: "heatmap",
-//   maxzoom: 9,
-//   type: "heatmap",
-//   paint: {
-//     // Increase the heatmap weight based on frequency and property magnitude
-//     "heatmap-weight": [
-//       "interpolate",
-//       ["linear"],
-//       ["get", "sentiment"],
-//       0,
-//       0,
-//       1,
-//       1,
-//     ],
-//     // Increase the heatmap color weight weight by zoom level
-//     // heatmap-intensity is a multiplier on top of heatmap-weight
-//     "heatmap-intensity": [
-//       "interpolate",
-//       ["linear"],
-//       ["zoom"],
-//       0,
-//       1,
-//       MAX_ZOOM_LEVEL,
-//       3,
-//     ],
-
-//     // Color ramp for heatmap.  Domain is 0 (low) to 1 (high).
-//     // Begin color ramp at 0-stop with a 0-transparancy color
-//     // to create a blur-like effect.
-//     "heatmap-color": [
-//       "interpolate",
-//       ["linear"],
-//       ["heatmap-density"],
-//       0,
-//       "rgba(33,102,172,0)",
-//       0.2,
-//       "#af8dc3",
-//       0.4,
-//       "#e7d4e8",
-//       0.6,
-//       "#d9f0d3",
-//       0.8,
-//       "#7fbf7b",
-//       0.9,
-//       "#1b7837",
-//     ],
-//     // Adjust the heatmap radius by zoom level
-//     "heatmap-radius": [
-//       "interpolate",
-//       ["linear"],
-//       ["zoom"],
-//       0,
-//       2,
-//       MAX_ZOOM_LEVEL,
-//       20,
-//     ],
-//     // Transition from heatmap to circle layer by zoom level
-//     "heatmap-opacity": ["interpolate", ["linear"], ["zoom"], 7, 1, 9, 0],
-//   },
-// };

--- a/frontend/src/hooks/useMapManager.ts
+++ b/frontend/src/hooks/useMapManager.ts
@@ -4,9 +4,10 @@ import { updateHeatMapLayer } from "~/heatmapLayer";
 import api from "~logic/api";
 import { isSuccessfulResponse } from "~/logic/api";
 import { useLocationPopup } from "./useLocationPopup";
-import { useRecoilState, useRecoilValue } from "recoil";
+import { useRecoilState, useRecoilValue, useSetRecoilState } from "recoil";
 import {
   circleLayerState,
+  isExpandedOverviewPanelState,
   mapFeatureCollectionState,
   mapViewStateState,
   selectedMonthState,
@@ -34,6 +35,8 @@ export function useMapManager() {
   const [mapViewState, setMapViewState] = useRecoilState(mapViewStateState);
 
   const [circleLayer, setCircleLayer] = useRecoilState(circleLayerState);
+
+  const setIsExpandedOverviewPanel = useSetRecoilState(isExpandedOverviewPanelState);
 
   const setLayer = () => {
     console.log(featureCollection.features);
@@ -91,13 +94,14 @@ export function useMapManager() {
       0
     ); // set day to 0 to get last day of the previous month
 
-    // format dates to YYYY-MM-DD
+  // format dates to YYYY-MM-DD
     const fromDate = firstDay.toISOString().split("T")[0];
     const toDate = lastDay.toISOString().split("T")[0];
 
     const res = await searchByLocation(location, fromDate, toDate);
     
     if (isSuccessfulResponse(res)) {
+      setIsExpandedOverviewPanel(false);
       handlePopupOpen({
         longitude: lng,
         latitude: lat,

--- a/frontend/src/hooks/useOverviewPanel.ts
+++ b/frontend/src/hooks/useOverviewPanel.ts
@@ -172,7 +172,7 @@ export function getCountKey(
 ): string {
   return (
     (selectedMonth
-      ? `${selectedMonth.toString()}-${selectedYear.toString()}`
+      ? `${selectedMonth.toString().padStart(2, "0")}-${selectedYear.toString()}`
       : `${selectedYear.toString()}`) + "-count"
   );
 }
@@ -183,7 +183,7 @@ export function getSentimentKey(
 ): string {
   return (
     (selectedMonth
-      ? `${selectedMonth.toString()}-${selectedYear.toString()}`
+      ? `${selectedMonth.toString().padStart(2, "0")}-${selectedYear.toString()}`
       : `${selectedYear.toString()}`) + "-sentiment"
   );
 }


### PR DESCRIPTION
…to circle colors and sizes

Fixed the following bugs:
- Fixed issue with search results being misaligned. Had to wrap the circle (corresponding to sentiment color) and the thumbnail in a container and set the outer-container style to justify-content: space-between
- Fixed issue with overview panel stats not appearing for certain months (was an issue with formatting the keys used to find count and sentiment values in each feature's properties map)
- Fixed alignment and display issues with the unfold more icon not being centered when condensing the overview panel. Also made space between the overview panel title and the unfold less icon

Other changes:
- Made some changes to the circle colors based on sentiment score (<= 0.2 is red, 0.5 is yellow, >=0.8 is green). Values between are interpolated. This seems appropriate based on the actual data and articles. Made sure the same method is used for the circle colors shown in the search results and the overview panel. 
- Also made same changes to circle sizing so that they sizes are interpolated between the max count for a chosen date range and the lowest count (i.e. 1). The max count just refers to the feature that is most mentioned. Circles look nicer now and their sizes make more sense. 